### PR TITLE
Revise the grammar problem of the "fit“ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # PCA Face Recognition
 
-Fit: Based on the following predictor variables we fit the PLS model.
-eventType, volunteerCertification, totalNumber, eventLocation, volunteerBonus, volunteerScore, satisfy
-Note: Latent variables that are subset of set of predictor variables are determined by PLS.
+Fit: Based on the predictor variables eventType, volunteerCertification, totalNumber, eventLocation, volunteerBonus, volunteerScore, we fit the PLS model and satisfy the note: Latent variables that are subsets of the set of predictor variables determined by the PLS model.
 
 Apply: We apply the multivariate regression model to predict following response variables.
 eventBudget, volunteerNumber 


### PR DESCRIPTION
1. The subject of "satisfy note" is missing and corrected by connected to the first sentence.

2. The list of the predictor variables is moved to the first sentence to avoid misunderstanding of the second sentence.
 
3. The plurality of "subset" is corrected.