### PR TITLE
remove redundancy in "Event prediction"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Apply:
 Algorithm Description:
 Event Prediction:
 
-From the set of predictor variables we would like to predict set of response variables. Reasonable solution to tackle this problem is to build a multivariate regression model from training event data that can predict response variables from set of testing event data. Partial least square (PLS) is a popular choice as it learns the latent variables utilizing the relationship between predictor and response variables in the training dataset. We particularly utilized NIPALS algorithm  (https://en.wikipedia.org/wiki/Non-linear_iterative_partial_least_squares) which is a kind of PLS technique.  
+A multivariate regression model from training event data is built to predict response variables from the set of the predictor variables of testing event data. Partial least square (PLS) is a popular choice as it learns the latent variables utilizing the relationship between predictor and response variables in the training dataset. We particularly utilized NIPALS algorithm  (https://en.wikipedia.org/wiki/Non-linear_iterative_partial_least_squares) which is a kind of PLS technique.  
 
 Face Recognition:
 Training phase: 


### PR DESCRIPTION
1. In the "Event prediction" section, the first sentence states the need to predict the variables. The second sentence provides the solution for the need. By combining this two sentence, redundancy is removed by stating the model was built. 

2. "Reasonable solution to tackle this problem is to" is a metadiscourse and is revised.